### PR TITLE
Fix test output

### DIFF
--- a/git_fleximod/git_fleximod.py
+++ b/git_fleximod/git_fleximod.py
@@ -195,18 +195,19 @@ def submodules_status(gitmodules, root_dir, toplevel=False, depth=0):
         submod = init_submodule_from_gitmodules(gitmodules, name, root_dir, logger)
             
         result,n,l,t = submod.status()
-        testfails += t
-        localmods += l
-        needsupdate += n
         if toplevel or not submod.toplevel():
             print(wrapper.fill(result))
-        subdir = os.path.join(root_dir, submod.path)
-        if os.path.exists(os.path.join(subdir, ".gitmodules")):
-            submod = GitModules(logger, confpath=subdir)
-            t,l,n = submodules_status(submod, subdir, depth=depth+1)
             testfails += t
             localmods += l
             needsupdate += n
+        subdir = os.path.join(root_dir, submod.path)
+        if os.path.exists(os.path.join(subdir, ".gitmodules")):
+            gsubmod = GitModules(logger, confpath=subdir)
+            t,l,n = submodules_status(gsubmod, subdir, depth=depth+1)
+            if toplevel or not submod.toplevel():
+                testfails += t
+                localmods += l
+                needsupdate += n
             
     return testfails, localmods, needsupdate
 

--- a/git_fleximod/submodule.py
+++ b/git_fleximod/submodule.py
@@ -92,7 +92,7 @@ class Submodule():
                 needsupdate = True
             else:
                 result = f"e {self.name:>20} has no fxtag defined in .gitmodules{optional}"
-                testfails = True
+                testfails = False
         else:
             with utils.pushd(smpath):
                 git = GitInterface(smpath, self.logger)
@@ -122,9 +122,11 @@ class Submodule():
                 if self.fxtag and atag == self.fxtag:
                     result = f"  {self.name:>20} at tag {self.fxtag}"
                     recurse = True
+                    testfails = False
                 elif self.fxtag and ahash[: len(self.fxtag)] == self.fxtag:
                     result = f"  {self.name:>20} at hash {ahash}"
                     recurse = True
+                    testfails = False
                 elif atag == ahash:
                     result = f"  {self.name:>20} at hash {ahash}"
                     recurse = True
@@ -133,14 +135,17 @@ class Submodule():
                     testfails = True
                     needsupdate = True
                 else:
-                    result = f"e {self.name:>20} has no fxtag defined in .gitmodules, module at {atag}"
-                    testfails = True
+                    if atag:
+                        result = f"e {self.name:>20} has no fxtag defined in .gitmodules, module at {atag}"
+                    else:
+                        result = f"e {self.name:>20} has no fxtag defined in .gitmodules, module at {ahash}"
+                    testfails = False
                     
                 status = git.git_operation("status", "--ignore-submodules", "-uno")
                 if "nothing to commit" not in status:
                     localmods = True
                     result = "M" + textwrap.indent(status, "                      ")
-        
+#        print(f"result {result} needsupdate {needsupdate} localmods {localmods} testfails {testfails}")
         return result, needsupdate, localmods, testfails
 
     

--- a/git_fleximod/submodule.py
+++ b/git_fleximod/submodule.py
@@ -106,10 +106,16 @@ class Submodule():
                 line = git.git_operation("log", "--pretty=format:\"%h %d").partition('\n')[0]
                 parts = line.split()
                 ahash = parts[0][1:]
+                atag = None
                 if len(parts) > 3:
-                    atag = parts[3][:-1]
-                else:
-                    atag = None
+                    idx = 0
+                    while idx < len(parts)-1:
+                        idx = idx+1
+                        if parts[idx] == 'tag:':
+                            atag = parts[idx+1][:-1]
+                            if atag == self.fxtag:
+                                break
+
                 
                 #print(f"line is {line} ahash is {ahash} atag is {atag}")
                 #                atag = git.git_operation("describe", "--tags", "--always").rstrip()


### PR DESCRIPTION
Changes the way tags are identified to fix a problem when more that two tags identify a hash.   Fix overcount of errors in git fleximod test