### PR TITLE
Fix/nonexistanttag

### DIFF
--- a/git_fleximod/git_fleximod.py
+++ b/git_fleximod/git_fleximod.py
@@ -124,8 +124,8 @@ def submodule_sparse_checkout(root_dir, name, url, path, sparsefile, tag="master
     # set the repository remote
 
     logger.info("Setting remote origin in {}/{}".format(root_dir, path))
-    status = sprepo_git.git_operation("remote", "-v")
-    if url not in status:
+    _, remotelist = sprepo_git.git_operation("remote", "-v")
+    if url not in remotelist:
         sprepo_git.git_operation("remote", "add", "origin", url)
 
     topgit = os.path.join(gitroot, ".git")
@@ -213,7 +213,7 @@ def submodules_status(gitmodules, root_dir, toplevel=False, depth=0):
 
 def git_toplevelroot(root_dir, logger):
     rgit = GitInterface(root_dir, logger)
-    superroot = rgit.git_operation("rev-parse", "--show-superproject-working-tree")
+    _, superroot = rgit.git_operation("rev-parse", "--show-superproject-working-tree")
     return superroot
 
 def submodules_update(gitmodules, root_dir, requiredlist, force):

--- a/git_fleximod/gitinterface.py
+++ b/git_fleximod/gitinterface.py
@@ -59,11 +59,12 @@ class GitInterface:
         command = self._git_command(operation, *newargs)
         if isinstance(command, list):
             try:
-                return utils.execute_subprocess(command, output_to_caller=True)
+                status, output = utils.execute_subprocess(command, status_to_caller=True, output_to_caller=True)
+                return status, output.rstrip()
             except Exception as e:
                 sys.exit(e)
         else:
-            return command
+            return 0, command
 
     def config_get_value(self, section, name):
         if self._use_module:

--- a/git_fleximod/submodule.py
+++ b/git_fleximod/submodule.py
@@ -61,7 +61,8 @@ class Submodule():
             rootgit = GitInterface(self.root_dir, self.logger)
             # submodule commands use path, not name
             status, tags = rootgit.git_operation("ls-remote", "--tags", self.url)
-            status, result = rootgit.git_operation("submodule","status",smpath).split()
+            status, result = rootgit.git_operation("submodule","status",smpath)
+            result = result.split()
             
             if result:
                 ahash = result[0][1:]
@@ -153,7 +154,7 @@ class Submodule():
                 status, output = git.git_operation("status", "--ignore-submodules", "-uno")
                 if "nothing to commit" not in output:
                     localmods = True
-                    result = "M" + textwrap.indent(status, "                      ")
+                    result = "M" + textwrap.indent(output, "                      ")
 #        print(f"result {result} needsupdate {needsupdate} localmods {localmods} testfails {testfails}")
         return result, needsupdate, localmods, testfails
 
@@ -225,10 +226,9 @@ class Submodule():
         rootdotgit = os.path.join(self.root_dir, ".git")
         while os.path.isfile(rootdotgit):
             with open(rootdotgit) as f:
-                line = f.readline()
+                line = f.readline().rstrip()
                 if line.startswith("gitdir: "):
                     rootdotgit = os.path.abspath(os.path.join(self.root_dir,line[8:]))
-
         assert os.path.isdir(rootdotgit)
         # first create the module directory
         if not os.path.isdir(os.path.join(self.root_dir, self.path)):

--- a/git_fleximod/submodule.py
+++ b/git_fleximod/submodule.py
@@ -60,8 +60,8 @@ class Submodule():
         if not os.path.exists(os.path.join(smpath, ".git")):
             rootgit = GitInterface(self.root_dir, self.logger)
             # submodule commands use path, not name
-            tags = rootgit.git_operation("ls-remote", "--tags", self.url)
-            result = rootgit.git_operation("submodule","status",smpath).split()
+            status, tags = rootgit.git_operation("ls-remote", "--tags", self.url)
+            status, result = rootgit.git_operation("submodule","status",smpath).split()
             
             if result:
                 ahash = result[0][1:]
@@ -80,9 +80,9 @@ class Submodule():
                 result = f"e {self.name:>20} not checked out, aligned at tag {self.fxtag}{optional}"
                 needsupdate = True
             elif self.fxtag:
-                ahash = rootgit.git_operation(
+                status, ahash = rootgit.git_operation(
                     "submodule", "status", "{}".format(self.path)
-                ).rstrip()
+                )
                 ahash = ahash[1 : len(self.fxtag) + 1]
                 if self.fxtag == ahash:
                     result = f"e {self.name:>20} not checked out, aligned at hash {ahash}{optional}"
@@ -96,14 +96,15 @@ class Submodule():
         else:
             with utils.pushd(smpath):
                 git = GitInterface(smpath, self.logger)
-                remote = git.git_operation("remote").rstrip()
+                status, remote = git.git_operation("remote")
                 if remote == '':
                     result = f"e {self.name:>20} has no associated remote"
                     testfails = True
                     needsupdate = True
                     return result, needsupdate, localmods, testfails                    
-                rurl = git.git_operation("ls-remote","--get-url").rstrip()
-                line = git.git_operation("log", "--pretty=format:\"%h %d\"").partition('\n')[0]
+                status, rurl = git.git_operation("ls-remote","--get-url")
+                status, lines = git.git_operation("log", "--pretty=format:\"%h %d\"")
+                line = lines.partition('\n')[0]
                 parts = line.split()
                 ahash = parts[0][1:]
                 atag = None
@@ -120,7 +121,7 @@ class Submodule():
 
                 
                 #print(f"line is {line} ahash is {ahash} atag is {atag} {parts}")
-                #                atag = git.git_operation("describe", "--tags", "--always").rstrip()
+                #                atag = git.git_operation("describe", "--tags", "--always")
                 # ahash =  git.git_operation("rev-list", "HEAD").partition("\n")[0]
                     
                 recurse = False
@@ -149,8 +150,8 @@ class Submodule():
                         result = f"e {self.name:>20} has no fxtag defined in .gitmodules, module at {ahash}"
                     testfails = False
                     
-                status = git.git_operation("status", "--ignore-submodules", "-uno")
-                if "nothing to commit" not in status:
+                status, output = git.git_operation("status", "--ignore-submodules", "-uno")
+                if "nothing to commit" not in output:
                     localmods = True
                     result = "M" + textwrap.indent(status, "                      ")
 #        print(f"result {result} needsupdate {needsupdate} localmods {localmods} testfails {testfails}")
@@ -171,10 +172,11 @@ class Submodule():
         Returns:
             str: The name of the new remote if added, or the name of the existing remote that matches the submodule's URL.
         """ 
-        remotes = git.git_operation("remote", "-v").splitlines()
+        status, remotes = git.git_operation("remote", "-v")
+        remotes = remotes.splitlines()
         upstream = None
         if remotes:
-            upstream = git.git_operation("ls-remote", "--get-url").rstrip()
+            status, upstream = git.git_operation("ls-remote", "--get-url")
             newremote = "newremote.00"
             tmpurl = self.url.replace("git@github.com:", "https://github.com/")
             line = next((s for s in remotes if self.url in s or tmpurl in s), None)
@@ -214,7 +216,7 @@ class Submodule():
         """ 
         self.logger.info("Called sparse_checkout for {}".format(self.name))
         rgit = GitInterface(self.root_dir, self.logger)
-        superroot = rgit.git_operation("rev-parse", "--show-superproject-working-tree")
+        status, superroot = rgit.git_operation("rev-parse", "--show-superproject-working-tree")
         if superroot:
             gitroot = superroot.strip()
         else:
@@ -225,7 +227,7 @@ class Submodule():
             with open(rootdotgit) as f:
                 line = f.readline()
                 if line.startswith("gitdir: "):
-                    rootdotgit = os.path.abspath(os.path.join(self.root_dir,line[8:].rstrip()))
+                    rootdotgit = os.path.abspath(os.path.join(self.root_dir,line[8:]))
 
         assert os.path.isdir(rootdotgit)
         # first create the module directory
@@ -252,8 +254,8 @@ class Submodule():
         # set the repository remote
         
         self.logger.info("Setting remote origin in {}/{}".format(self.root_dir, self.path))
-        status = sprepo_git.git_operation("remote", "-v")
-        if self.url not in status:
+        status, remotes = sprepo_git.git_operation("remote", "-v")
+        if self.url not in remotes:
             sprepo_git.git_operation("remote", "add", "origin", self.url)
 
         topgit = os.path.join(gitroot, ".git")
@@ -296,9 +298,11 @@ class Submodule():
 
         # Finally checkout the repo
         sprepo_git.git_operation("fetch", "origin", "--tags")
-        sprepo_git.git_operation("checkout", self.fxtag)
-
-        print(f"Successfully checked out {self.name:>20} at {self.fxtag}")
+        status,_ = sprepo_git.git_operation("checkout", self.fxtag)
+        if status:
+            print(f"Error checking out {self.name:>20} at {self.fxtag}")
+        else:
+            print(f"Successfully checked out {self.name:>20} at {self.fxtag}")
         rgit.config_set_value(f'submodule "{self.name}"', "active", "true")
         rgit.config_set_value(f'submodule "{self.name}"', "url", self.url)
         rgit.config_set_value(f'submodule "{self.name}"', "path", self.path)
@@ -348,7 +352,7 @@ class Submodule():
                     git.git_operation("clone", self.url, self.path)
                     smgit = GitInterface(repodir, self.logger)
                     if not tag:
-                        tag = smgit.git_operation("describe", "--tags", "--always").rstrip()
+                        status, tag = smgit.git_operation("describe", "--tags", "--always")
                     smgit.git_operation("checkout", tag)
                     # Now need to move the .git dir to the submodule location
                     rootdotgit = os.path.join(self.root_dir, ".git")
@@ -356,7 +360,7 @@ class Submodule():
                         with open(rootdotgit) as f:
                             line = f.readline()
                             if line.startswith("gitdir: "):
-                                rootdotgit = line[8:].rstrip()
+                                rootdotgit = line[8:]
 
                     newpath = os.path.abspath(os.path.join(self.root_dir, rootdotgit, "modules", self.name))
                     if os.path.exists(newpath):
@@ -399,15 +403,16 @@ class Submodule():
                 git = GitInterface(submoddir, self.logger)
                 # first make sure the url is correct
                 newremote = self._add_remote(git)
-                tags = git.git_operation("tag", "-l")
+                status, tags = git.git_operation("tag", "-l")
                 fxtag = self.fxtag
                 if fxtag and fxtag not in tags:
                     git.git_operation("fetch", newremote, "--tags")
-                atag = git.git_operation("describe", "--tags", "--always").rstrip()
+                status, atag = git.git_operation("describe", "--tags", "--always")
                 if fxtag and fxtag != atag:
                     try:
-                        git.git_operation("checkout", fxtag)
-                        print(f"{self.name:>20} updated to {fxtag}")
+                        status, _ = git.git_operation("checkout", fxtag)
+                        if not status:
+                            print(f"{self.name:>20} updated to {fxtag}")
                     except Exception as error:
                         print(error)
                     

--- a/git_fleximod/utils.py
+++ b/git_fleximod/utils.py
@@ -307,12 +307,15 @@ def execute_subprocess(commands, status_to_caller=False, output_to_caller=False)
         # simple status check. If returning, it is the callers
         # responsibility determine if an error occurred and handle it
         # appropriately.
-        if not return_to_caller:
-            msg_context = (
-                "Process did not run successfully; "
-                "returned status {0}".format(error.returncode)
-            )
-            msg = failed_command_msg(msg_context, commands, output=error.output)
+        msg_context = (
+            "Process did not run successfully; "
+            "returned status {0}".format(error.returncode)
+        )
+        msg = failed_command_msg(msg_context, commands, output=error.output)
+        if return_to_caller:
+            logging.warning(error)
+            logging.warning(msg)
+        else:
             logging.error(error)
             logging.error(msg)
             log_process_output(error.output)


### PR DESCRIPTION
Fixes issues with system interface to git by returning the status flag along with the combined stdout and stderr flags.  

Fixes issue #61 which is misnamed - the problem was that git-fleximod wasn't reporting a user error when a user requested a non-existent tag.