### PR TITLE
Asynchronous CESM check out (2x speed up)

### DIFF
--- a/git_fleximod/submodule.py
+++ b/git_fleximod/submodule.py
@@ -307,7 +307,7 @@ class Submodule():
         rgit.config_set_value('submodule.' + self.name, "url", self.url)
         rgit.config_set_value('submodule.' + self.name, "path", self.path)
 
-    def update(self):
+    async def update(self):
         """
         Updates the submodule to the latest or specified version.
 
@@ -378,7 +378,8 @@ class Submodule():
                 git.git_operation("submodule", "add", "--name", self.name, "--", self.url, self.path) 
 
             if not repo_exists:
-                git.git_operation("submodule", "update", "--init", "--", self.path)
+                git.git_operation("submodule", "init", "--", self.path)
+                await git.git_operation_async("submodule", "update", "--", self.path)
 
             if self.fxtag:        
                 smgit = GitInterface(repodir, self.logger)


### PR DESCRIPTION
**Heads-up:**  These changes do add some complexity to the codebase and the performance gain is limited to the initial execution of `git-fleximod update`, so I’d be completely fine if you prefer not to merge this PR in light of that tradeoff.

**Summary:** This PR refactors the `submodules_update` function into an asynchronous coroutine to enable concurrent submodule updates during the initial checkout of CESM. 

**Performance gain:**  Initial CESM check out got faster by roughly a factor of two by hiding GitHub network latency via asynchronous git operations.

**Implementation details:** 
- I used Python’s standard asyncio library to concurrently schedule IO-bound `git submodule update` commands. (Other independent git commands could be made asynchronous as well, but I avoided doing so to keep complexity down given the limited additional benefit.) 
- This all uses a single Python thread, and is a thread-safe version of the previous attempt. 
- In this version, `git submodule update --init` is split into two steps: `git submodule init` and `git submodule update`. The former, along with other git operations that may touch shared `.git/modules` state, is executed serially (though asynchronously). The latter (`git submodule update`) runs concurrently since it is heavily network-bound, not CPU-bound, and does not modify shared state. 
- Note that the Python code runs on a single thread (using asynchronous scheduling), but the `git submodule update` commands are executed in parallel by the operating system. As a result, CPU usage roughly doubles but remains below 40%. 